### PR TITLE
Change the index to 0 instead of -1

### DIFF
--- a/deeprc/dataset_readers.py
+++ b/deeprc/dataset_readers.py
@@ -324,7 +324,7 @@ class RepertoireDataset(Dataset):
         # Read target data from csv file
         self.metadata = pd.read_csv(self.metadata_filepath, sep=self.metadata_file_column_sep, header=0, dtype=str)
         self.metadata.index = self.metadata[self.sample_id_column].values
-        self.sample_keys = np.array([os.path.splitext(k)[-1] for k in self.metadata[self.sample_id_column].values])
+        self.sample_keys = np.array([os.path.splitext(k)[0] for k in self.metadata[self.sample_id_column].values])
         self.n_samples = len(self.sample_keys)
         self.target_features = self.task_definition.get_targets(self.metadata)
         
@@ -337,7 +337,7 @@ class RepertoireDataset(Dataset):
             self.n_features = len(self.aas)
             self.stats = str_or_byte_to_str(metadata['stats'][()])
             self.n_samples = metadata['n_samples'][()]
-            hdf5_sample_keys = [str_or_byte_to_str(os.path.splitext(k)[-1]) for k in metadata['sample_keys'][:]]
+            hdf5_sample_keys = [str_or_byte_to_str(os.path.splitext(k)[0]) for k in metadata['sample_keys'][:]]
             
             # Mapping metadata sample indices -> hdf5 file sample indices
             unfound_samples = np.array([sk not in hdf5_sample_keys for sk in self.sample_keys], dtype=np.bool)


### PR DESCRIPTION
`self.sample_keys` and `hdf5_sample_keys` both use -1 to index the output of the split method, so `self.sample_keys` ends up being a list of extensions, e.g. ".tsv" or a list of empty strings depending on whether `self.metadata[self.sample_id_column]` has the file names with or without the extension of each file, respectively. `hdf5_sample_keys` would also end up being a list of extensions. 

Then, `unfound_samples` would not pick the error in case both lists have the extensions, and `self.hdf5_inds` would end up having the same index `0`, because of how the `.index()` method works.

Consequently, the data loader would end up loading the same repertoire because `sample_sequences_start_end` would have the same start:end pairs, except that it will load them with different targets because the latter is sampled separately.

This was at least my experience running, e.g. the `example_single_task_cnn.py` file with the example dataset :)